### PR TITLE
adding start of aws to include instances in solve

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ I think I'm still going to use Python for faster prototyping.
 - aws instance listing (based on regions) should validate regions - an invalid regions simply returns no results
 - could eventually support different resource types (beyond compute or types of prices, e.g., pre-emptible vs. on demand)
 - add GPU memory - available in AWS not sure gcp
+- add AWS description from metadata (similar to GCP)
 
 Planning for minimizing cost:
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,11 @@ Or write the atoms to file:
 $ cloud-select instance --memory 4 --out atoms.lp
 ```
 
+Ask for a specific cloud on the command line (note you can also ask via your settings.yml configuration file for a more permanent default):
+
+```bash
+$ cloud-select --cloud google instance --cpus-min 200 --cpus-max 400
+```
 
 ## Design
 
@@ -158,6 +163,10 @@ I think I'm still going to use Python for faster prototyping.
 - how to handle instances that don't have an attribute of interest? Should we unselect them?
 - pretty branded documentation
 - selection should have sorting ability
+- should we allow currency outside USD? Probably not for now.
+- aws instance listing (based on regions) should validate regions - an invalid regions simply returns no results
+- could eventually support different resource types (beyond compute or types of prices, e.g., pre-emptible vs. on demand)
+- add GPU memory - available in AWS not sure gcp
 
 Planning for minimizing cost:
 

--- a/cloud_select/client/__init__.py
+++ b/cloud_select/client/__init__.py
@@ -119,7 +119,6 @@ def get_parser():
         help="one or more clouds to include (if not provided, all are attempted).",
         choices=cloud.cloud_names,
         action="append",
-        default=cloud.cloud_names,
     )
 
     parser.add_argument(
@@ -188,7 +187,7 @@ cloud-select -c rm:registry:/tmp/registry""",
     )
 
     instance.add_argument(
-        "--out-asp",
+        "--asp",
         dest="asp_out",
         help="Write ASP atoms to output file.",
     )

--- a/cloud_select/client/instance.py
+++ b/cloud_select/client/instance.py
@@ -21,6 +21,7 @@ def main(args, parser, extra, subparser):
         settings_file=args.settings_file,
         cache_dir=args.cache_dir,
         cache_expire=args.cache_expire,
+        clouds=args.clouds,
     )
 
     # Update config settings on the fly

--- a/cloud_select/main/cloud/__init__.py
+++ b/cloud_select/main/cloud/__init__.py
@@ -1,6 +1,5 @@
+from .aws import AmazonCloud
 from .google import GoogleCloud
 
-# from .aws import AmazonCloud
-
-clouds = {"google": GoogleCloud}
+clouds = {"google": GoogleCloud, "aws": AmazonCloud}
 cloud_names = list(clouds)

--- a/cloud_select/main/cloud/aws/__init__.py
+++ b/cloud_select/main/cloud/aws/__init__.py
@@ -1,0 +1,1 @@
+from .client import AmazonCloud

--- a/cloud_select/main/cloud/aws/client.py
+++ b/cloud_select/main/cloud/aws/client.py
@@ -114,13 +114,6 @@ class AmazonCloud(CloudProvider):
         """
         return AmazonInstanceGroup(data)
 
-    def fail_message(self, message):
-        """
-        Shared message and empty return if auth not set
-        """
-        logger.info(f"{self.name}: cannot retrieve {message}.")
-        return []
-
     def _set_services(self):
         """
         Connect to needed amazon clients.

--- a/cloud_select/main/cloud/aws/client.py
+++ b/cloud_select/main/cloud/aws/client.py
@@ -1,0 +1,148 @@
+# Copyright 2022 Lawrence Livermore National Security, LLC and other
+# HPCIC DevTools Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+
+import cloud_select.utils as utils
+from cloud_select.logger import logger
+
+from ..base import CloudProvider
+from .instance import AmazonInstanceGroup
+from .prices import AmazonPrices
+
+
+class AmazonCloud(CloudProvider):
+    """
+    An Amazon cloud provider wrapper
+    """
+
+    name = "aws"
+
+    def __init__(self, **kwargs):
+        self.regions = ["us-east-1"]
+        self.project = None
+        self.ec2_client = None
+        self.pricing_cli = None
+
+        # This currently has two pieces - billing and instances (different APIs)
+        self._set_services()
+        super(AmazonCloud, self).__init__()
+
+    def prices(self):
+        """
+        Use the API to retrieve and return prices to cache.
+        """
+        # TODO - this currently can't be finished because I don't have the right permissions.
+        if not self.has_pricing_auth:
+            return self.fail_message("prices, authentication not set.")
+
+        # Get services first - there are almost 2k! Look for compute engine
+        logger.info(f"Retrieving prices for {self.name}.")
+
+        # This is how we get the service types we can ask for
+        # response = self.pricing_cli.describe_services(ServiceCode="AmazonEC2")
+        # And next we get the list of instance types (on the order of 600)
+        next_token = ""
+        instance_types = []
+        while True:
+            response = self.pricing_cli.get_attribute_values(
+                ServiceCode="AmazonEC2",
+                AttributeName="instanceType",
+                NextToken=next_token,
+            )
+            if not response.get("NextToken"):
+                break
+            next_token = response.get("NextToken")
+            instance_types += [x["Value"] for x in response["AttributeValues"]]
+            print(f"{len(instance_types)} total instances...", end="\r")
+
+        # Now we get prices for those
+        query = [
+            {"Type": "TERM_MATCH", "Field": "instanceType", "Value": x}
+            for x in instance_types
+        ]
+        response = self.pricing_cli.get_products(ServiceCode="AmazonEC2", Filters=query)
+        return self.load_prices(response)
+
+    def instances(self):
+        """
+        Use the API to retrieve (and return) instances within a set of regions.
+        """
+        if not self.has_instance_auth:
+            return self.fail_message("instances, authentication not set.")
+
+        logger.info(f"Retrieving instances for {self.name}")
+
+        # Get instance types in the region - give a warning if no response.
+        response = self.ec2_client.describe_instance_type_offerings(
+            DryRun=False,
+            LocationType="region",
+            Filters=[{"Name": "location", "Values": self.regions}],
+        )
+        if not response["InstanceTypeOfferings"]:
+            logger.warning(
+                f"No instance types found for region selection {self.regions} - are you sure these are correct?"
+            )
+            return
+
+        # This list has (it appears unique) machine type, and location - we need to use the API to get details
+        machine_types = list(
+            set([x["InstanceType"] for x in response["InstanceTypeOfferings"]])
+        )
+
+        # From what I can tell, we don't have next pages for this smaller list.
+        # We can only ask in increments of 100
+        instances = []
+        for chunk in utils.chunks(machine_types, 100):
+            response = self.ec2_client.describe_instance_types(
+                DryRun=False, InstanceTypes=chunk
+            )
+            instances += response.get("InstanceTypes", [])
+
+        # Return a wrapped set of instances
+        return self.load_instances(instances)
+
+    def load_prices(self, data):
+        """
+        Load prices data from json instal class
+        """
+        return AmazonPrices(data)
+
+    def load_instances(self, data):
+        """
+        Load instance data from json.
+        """
+        return AmazonInstanceGroup(data)
+
+    def fail_message(self, message):
+        """
+        Shared message and empty return if auth not set
+        """
+        logger.info(f"{self.name}: cannot retrieve {message}.")
+        return []
+
+    def _set_services(self):
+        """
+        Connect to needed amazon clients.
+
+        https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Client.describe_instance_types
+        """
+        import boto3
+
+        self.ec2_client = boto3.client("ec2")
+        self.pricing_cli = boto3.client("pricing")
+
+        try:
+            self.ec2_client.describe_instances()
+            self.has_instance_auth = True
+        except Exception as e:
+            logger.warning(f"Unable to authenticate to Amazon Web Services EC2: {e}")
+            self.has_instance_auth = False
+
+        # Note: purposefully set to false because we don't have an API token to test
+        try:
+            self.pricing_cli.describe_services(ServiceCode="AmazonEC2")
+            self.has_pricing_auth = False
+        except Exception as e:
+            logger.warning(f"Unable to authenticate to Amazon Web Services EC2: {e}")
+            self.has_pricing_auth = False

--- a/cloud_select/main/cloud/aws/instance.py
+++ b/cloud_select/main/cloud/aws/instance.py
@@ -1,0 +1,76 @@
+# Copyright 2022 Lawrence Livermore National Security, LLC and other
+# HPCIC DevTools Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+
+from ..base import Instance, InstanceGroup
+
+
+class AmazonInstance(Instance):
+    @property
+    def name(self):
+        return self.data.get("InstanceType")
+
+    def attr_cpus(self):
+        """
+        Number of cpus the instance has.
+        """
+        return self.data.get("VCpuInfo", {}).get("DefaultVCpus")
+
+    def attr_memory(self):
+        """
+        Memory is in GB
+        """
+        mb = self.data.get("MemoryInfo", {}).get("SizeInMiB")
+        if mb:
+            return int(mb / 1024)
+
+    def attr_free_tier(self):
+        """
+        Determine if an instance is free tier.
+        """
+        return self.data.get("FreeTierEligible")
+
+    def attr_ipv6(self):
+        """
+        Determine if an instance can support ipv6
+        """
+        return self.data.get("NetworkInfo", {}).get("Ipv6Supported")
+
+    def attr_gpu(self):
+        """
+        Determine if an instance can support gpu
+        """
+        return "GpuInfo" in self.data and self.data["GpuInfo"]
+
+    def attr_gpus(self):
+        """
+        Determine number of gpus an instance can support.
+        """
+        gpus = self.data.get("GpuInfo", {}).get("Gpus")
+        if not gpus:
+            return
+        count = 0
+        for gpu_spec in gpus:
+            count += gpu_spec["Count"]
+        return count
+
+
+class AmazonInstanceGroup(InstanceGroup):
+    """
+    A Google Cloud instance group.
+
+    An instance group stores raw data, and allows for query or
+    other interaction over instances.
+    """
+
+    name_attribute = "InstanceType"
+    Instance = AmazonInstance
+
+    def add_instance_prices(self, prices):
+        """
+        Add pricing information to instances
+
+        https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/pricing.html
+        """
+        print("TODO add prices")

--- a/cloud_select/main/cloud/aws/prices.py
+++ b/cloud_select/main/cloud/aws/prices.py
@@ -1,0 +1,14 @@
+# Copyright 2022 Lawrence Livermore National Security, LLC and other
+# HPCIC DevTools Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+
+from ..base import Prices
+
+
+class AmazonPrices(Prices):
+    """
+    Google Compute Engine prices
+    """
+
+    pass

--- a/cloud_select/main/cloud/google/instance.py
+++ b/cloud_select/main/cloud/google/instance.py
@@ -42,8 +42,7 @@ class GoogleCloudInstance(Instance):
         saying it _could_ be free tier but isn't necessarily if you've used
         your monthly allowance. We will want to add that preamble somewhere.
         """
-        # We treat booleans as lowercase strings
-        return str("micro" in self.name).lower()
+        return "micro" in self.name
 
     def attr_ipv6(self):
         """
@@ -95,3 +94,25 @@ class GoogleCloudInstanceGroup(InstanceGroup):
 
     name_attribute = "name"
     Instance = GoogleCloudInstance
+
+    def add_instance_prices(self, prices):
+        """
+        Add pricing information to instances
+
+        Prices have these categories:
+          - {'Compute', 'License', 'Network', 'Storage'}
+        And these usage types:
+          - {'Commit1Mo', 'Commit1Yr', 'Commit3Yr', 'OnDemand', 'Preemptible'}
+
+        For now we will filter to "Compute" and "OnDemand" but these could be changed.
+        """
+        # Filter down to compute
+        data = [
+            x
+            for x in prices.data
+            if x["category"]["resourceFamily"] == "Compute"
+            and x["category"]["usageType"] == "OnDemand"
+        ]
+        assert data
+        # TODO - here we have a lsiting with snapshot, CPU, RAM, and I suspect we will need to combine attributes to get costs
+        # for instances. This is a TODO I want help with. For now, we do nothing

--- a/cloud_select/utils/__init__.py
+++ b/cloud_select/utils/__init__.py
@@ -17,6 +17,7 @@ from .fileio import (
     write_json,
     write_yaml,
 )
+from .misc import chunks
 from .terminal import (
     check_install,
     confirm_action,

--- a/cloud_select/utils/misc.py
+++ b/cloud_select/utils/misc.py
@@ -1,0 +1,12 @@
+# Copyright 2022 Lawrence Livermore National Security, LLC and other
+# HPCIC DevTools Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+
+
+def chunks(listing, chunk_size):
+    """
+    Yield successive chunks from listing. Chunkify!
+    """
+    for i in range(0, len(listing), chunk_size):
+        yield listing[i : i + chunk_size]

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,5 +6,6 @@ per-file-ignores =
     cloud_select/utils/__init__.py:F401
     cloud_select/main/__init__.py:F401
     cloud_select/main/cloud/__init__.py:F401
+    cloud_select/main/cloud/aws/__init__.py:F401
     cloud_select/main/cloud/google/__init__.py:F401
     cloud_select/main/solve/__init__.py:F401


### PR DESCRIPTION
This PR will:

- add support for adding AWS instances to the solve (see picture below, and yes we need to derive our own descriptions) 
![image](https://user-images.githubusercontent.com/814322/205779491-201824fb-6b21-4978-a65e-0c2ff5edb005.png)
- add plumbing that gets and saves GCP pricing data. Matching these to instances is another thing we will need to think about.
- Start of pluming for AWS prices, but I don't have correct permissions.
- Changed output type for asp file to just `--asp` because that's what I wanted to use

It's been interesting comparing the two APIs - AWS is a lot richer in  terms of metadata for instances. I suspect their pricing API might have more transparency but I haven't seen it yet. I'm also doing my best to have shared functionality for the top level classes (e.g., Instance that is base class for GoogleCloudInstance and AmazonInstance).

Anyway, this is good progress! Still a lot to do, but having fun and will get there :) I'm going to chomp off as many of these TODOs as I can on my own, and when I'm ready to share with the group will write up remaining work into more robust TODOs for the group to think about.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>