### PR TITLE
Adding support for matching aws prices to instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ See our current [design document](docs/design.md) for background about design.
 - [ ] should cache be organized by region to allow easier filter (data for AWS doesn't have that attribute)
 - [ ] need to do something with costs
 - [ ] test performance of using solver vs. not
+- [ ] can we just scrape prices from? https://cloud.google.com/compute/all-pricing
 
 ### Future desires
 

--- a/cloud_select/client/__init__.py
+++ b/cloud_select/client/__init__.py
@@ -10,6 +10,7 @@ import os
 import sys
 
 import cloud_select
+import cloud_select.defaults as defaults
 import cloud_select.main.cloud as cloud
 import cloud_select.main.schemas as schemas
 from cloud_select.logger import setup_logger
@@ -126,7 +127,7 @@ def get_parser():
         "--sort-by",
         dest="sort_by",
         help="Sort by a result attribute.",
-        choices=["name", "cpus", "gpus", "memory"],
+        choices=defaults.sort_by_fields,
     )
     parser.add_argument(
         "--asc",

--- a/cloud_select/defaults.py
+++ b/cloud_select/defaults.py
@@ -22,6 +22,10 @@ user_settings_file = os.path.join(userhome, "settings.yml")
 cache_dir = os.path.join(userhome, "cache")
 cache_expire = 128  # one week is 128 hours
 
+# Fields and arguments for client
+sort_by_fields = ["name", "memory", "cpus", "gpus", "price"]
+table_descriptors = {"price": "*Price in USD/hour"}
+
 # variables in settings that allow environment variable expansion
 allowed_envars = ["HOME"]
 

--- a/cloud_select/main/cloud/aws/instance.py
+++ b/cloud_select/main/cloud/aws/instance.py
@@ -5,6 +5,8 @@
 
 import re
 
+from cloud_select.logger import logger
+
 from ..base import Instance, InstanceGroup
 
 
@@ -13,11 +15,20 @@ class AmazonInstance(Instance):
     def name(self):
         return self.data.get("InstanceType")
 
+    def attr_price(self):
+        """
+        Price of an instance, USD per hour.
+
+        This will only be populated - a single "Price" if prices are
+        enabled and present for the region.
+        """
+        return self.data.get("Price")
+
     def attr_region(self):
         """
-        Return the (| joined) listing of regions
+        Return the single region
         """
-        return "|".join(self.data.get("Regions", []))
+        return self.data.get("Region")
 
     def attr_description(self):
         """
@@ -93,10 +104,91 @@ class AmazonInstanceGroup(InstanceGroup):
         """
         self.data = [x for x in self.data if re.search(region, " ".join(x["Regions"]))]
 
+    def iter_instances(self):
+        """
+        Amazon provides regions together, so here we yield instance data with just one region.
+        """
+        for item in self.data:
+            regions = item.get("Regions")
+            if not regions:
+                yield self.Instance(item)
+                continue
+
+            # Provide finally as single region and price
+            for region in regions:
+                item["Region"] = region
+                item["Price"] = item.get("Prices", {}).get(region)
+                yield self.Instance(item)
+
     def add_instance_prices(self, prices):
         """
         Add pricing information to instances
 
+        We currently are filtering to:
+         - Linux
+         - OnDemand
+         - USD per hour
         https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/pricing.html
         """
-        print("TODO add prices")
+        lookup = {}
+        for price in prices.data:
+            if (
+                "instanceType" not in price["product"]["attributes"]
+                or "OnDemand" not in price["terms"]
+                or price["product"]["productFamily"] != "Compute Instance"
+            ):
+                continue
+
+            # I think we want BoxUsage https://docs.aws.amazon.com/cost-management/latest/userguide/ce-filtering.html
+            # Note that I also see HostBoxUsage and MIA1-BoxUsage but am filtering to those that start with BoxUsage for consistency
+            if price["product"]["attributes"][
+                "operatingSystem"
+            ] != "Linux" or not price["product"]["attributes"]["usagetype"].startswith(
+                "BoxUsage"
+            ):
+                continue
+
+            # The operation attribute looks like:
+            # operation: ['RunInstances:0004', 'RunInstances:0200', 'RunInstances:0100', 'RunInstances']
+            # And we have totally identical instances except for that, but in rates the numbers correspond to "extras" like enterprise, sql, web.
+            # So for now we just want to filter to vanilla "RunInstances" which looks like the raw EC2 price
+            if price["product"]["attributes"]["operation"] != "RunInstances":
+                continue
+
+            # How we will organize result entries
+            location = price["product"]["attributes"]["regionCode"]
+            instance_type = price["product"]["attributes"]["instanceType"]
+
+            assert len(price["terms"]["OnDemand"]) == 1
+            priceid = list(price["terms"]["OnDemand"].keys())[0]
+            for _, rate in price["terms"]["OnDemand"][priceid][
+                "priceDimensions"
+            ].items():
+                if rate["unit"].lower() == "hrs":
+                    if instance_type not in lookup:
+                        lookup[instance_type] = {}
+                    if location in lookup[instance_type]:
+                        logger.warning(
+                            "Found two rates for {instance_type} in {location} - we will choose one but this likely should not happen."
+                        )
+                    lookup[instance_type][location] = float(rate["pricePerUnit"]["USD"])
+
+        # Add prices to instances we have prices for
+        for instance in self.data:
+
+            # Set to unreasonably high so it's not a choice
+            if instance["InstanceType"] in lookup:
+
+                # Tell the group that we should add prices
+                self.prices_found = True
+
+                # Make a list of prices that matches regions
+                region_prices = {}
+                for region in instance["Regions"]:
+                    if region in lookup[instance["InstanceType"]]:
+                        region_prices[region] = lookup[instance["InstanceType"]][region]
+
+                    # Set to unreasonably high since we don't know
+                    else:
+                        region_prices.append(999999999999)
+                    instance["Prices"] = region_prices

--- a/cloud_select/main/cloud/aws/instance.py
+++ b/cloud_select/main/cloud/aws/instance.py
@@ -169,8 +169,9 @@ class AmazonInstanceGroup(InstanceGroup):
                         lookup[instance_type] = {}
                     if location in lookup[instance_type]:
                         logger.warning(
-                            "Found two rates for {instance_type} in {location} - we will choose one but this likely should not happen."
+                            f"Found two rates for {instance_type} in {location} - we will choose one but this likely should not happen."
                         )
+                    # These are provided as strings, since the original data is completely string
                     lookup[instance_type][location] = float(rate["pricePerUnit"]["USD"])
 
         # Add prices to instances we have prices for
@@ -179,16 +180,9 @@ class AmazonInstanceGroup(InstanceGroup):
             # Set to unreasonably high so it's not a choice
             if instance["InstanceType"] in lookup:
 
-                # Tell the group that we should add prices
-                self.prices_found = True
-
                 # Make a list of prices that matches regions
                 region_prices = {}
                 for region in instance["Regions"]:
                     if region in lookup[instance["InstanceType"]]:
                         region_prices[region] = lookup[instance["InstanceType"]][region]
-
-                    # Set to unreasonably high since we don't know
-                    else:
-                        region_prices.append(999999999999)
                     instance["Prices"] = region_prices

--- a/cloud_select/main/cloud/base.py
+++ b/cloud_select/main/cloud/base.py
@@ -131,6 +131,7 @@ class Instance(CloudData):
             "cloud": self.cloud,
             "name": self.name,
             "memory": self.attr_memory(),
+            "price": self.attr_price(),
             "cpus": self.attr_cpus(),
             "gpus": self.attr_gpus(),
             "region(s)": self.attr_region(),

--- a/cloud_select/main/cloud/google/instance.py
+++ b/cloud_select/main/cloud/google/instance.py
@@ -47,6 +47,14 @@ class GoogleCloudInstance(Instance):
         """
         return True
 
+    def attr_price(self):
+        """
+        Price of an instance, USD per hour.
+
+        This is not added for Google yet
+        """
+        return self.data.get("price")
+
     def attr_gpu(self):
         """
         Determine if an instance can support gpu

--- a/cloud_select/main/schemas.py
+++ b/cloud_select/main/schemas.py
@@ -5,6 +5,8 @@
 
 ## ContainerConfig Schema
 
+import cloud_select.defaults as defaults
+
 schema_url = "http://json-schema.org/draft-07/schema"
 
 # This is also for latest, and a list of tags
@@ -182,7 +184,7 @@ settings_properties = {
     "sort-by": {
         "type": "string",
         "description": "Sort by an attribute of interest.",
-        "enum": ["name", "memory", "cpus", "gpus"],
+        "enum": defaults.sort_by_fields,
     },
     "max-results": {
         "type": "number",

--- a/cloud_select/settings.yml
+++ b/cloud_select/settings.yml
@@ -12,7 +12,7 @@ cache_only: false
 
 # disable adding prices?
 # disabled for now because is a bit lengthy
-disable_prices: true
+disable_prices: false
 
 # cloud specific settings
 google:


### PR DESCRIPTION
This means we take the huge file from the AWS API, and do filters down to a set we are interested in and then match to instances we found based on identifier and region. The table now has prices, and when you sort it's filtered to those that we are able to sort by. Since at this point I want to be able to choose based on price I'm going to next try removing the solver and using basic iterable filtering.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>