### PR TITLE
fix: bug with max results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/converged-computing/cloud-select/tree/main) (0.0.x)
+ - fix one-off error for table listing (0.0.21)
  - add aws price cache example and use non-deprecated oras upload_* functions (0.0.2)
  - rename module to cloudselect (0.0.19)
  - bugfix for sorting by prices with select (0.0.18)

--- a/cloudselect/main/table.py
+++ b/cloudselect/main/table.py
@@ -104,7 +104,7 @@ class Table:
         column_width = self.available_width(columns)
         for i, row in enumerate(self.data):
             # have we gone over the limit?
-            if limit and i > limit:
+            if limit and i >= limit:
                 return
 
             parsed = []

--- a/cloudselect/version.py
+++ b/cloudselect/version.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (MIT)
 
-__version__ = "0.0.2"
+__version__ = "0.0.21"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "cloud-select-tool"


### PR DESCRIPTION
This will fix the off by one error.

```console
$ cloud-select --max-results 2 instance
Google Cloud instance prices derived from the web are limited to Iowa (us-central1)
                                 Cloud Instances Selected                                                                                 
┏━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┓                                                
┃ Cloud ┃ Name        ┃ Memory ┃ Price  ┃ Cpus ┃ Gpus ┃ Region    ┃ Description          ┃                                                
┡━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━╇━━━━━━╇━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━┩                                                
│ aws   │ r5b.xlarge  │ 32768  │ 0.298  │ 4    │      │ us-east-1 │ 4 vCPUs, 32.0 GiB... │                                                
│ aws   │ r7a.4xlarge │ 131072 │ 1.2172 │ 16   │      │ us-east-1 │ 16 vCPUs, 128.0 G... │                                                
└───────┴─────────────┴────────┴────────┴──────┴──────┴───────────┴──────────────────────┘                                                
*Price in USD/hour

$ cloud-select --max-results 3 instance
Google Cloud instance prices derived from the web are limited to Iowa (us-central1)
                                 Cloud Instances Selected                                                                                 
┏━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┓                                                
┃ Cloud ┃ Name        ┃ Memory ┃ Price  ┃ Cpus ┃ Gpus ┃ Region    ┃ Description          ┃                                                
┡━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━╇━━━━━━╇━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━┩                                                
│ aws   │ r5b.xlarge  │ 32768  │ 0.298  │ 4    │      │ us-east-1 │ 4 vCPUs, 32.0 GiB... │                                                
│ aws   │ r7a.4xlarge │ 131072 │ 1.2172 │ 16   │      │ us-east-1 │ 16 vCPUs, 128.0 G... │                                                
│ aws   │ g5g.metal   │ 131072 │        │ 64   │ 2    │ us-east-1 │ 64 vCPUs, 128.0 G... │                                                
└───────┴─────────────┴────────┴────────┴──────┴──────┴───────────┴──────────────────────┘                                                
*Price in USD/hour
```

- Fixes #29 