### PR TITLE
Update GPU vendor options

### DIFF
--- a/cloudselect/main/schemas.py
+++ b/cloudselect/main/schemas.py
@@ -116,7 +116,7 @@ instance_properties = {
         "description": "manufacturer of CPU",
         "enum": ["amd", "intel", "aws"],
     },
-    "gpu-vendor": {"type": "string", "enum": ["nvidia"]},
+    "gpu-vendor": {"type": "string", "enum": ["AMD", "Habana", "NVIDIA"]},
     "disk-type": {
         "type": "string",
         "description": "type of disk, hard disk or solid state",

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -121,7 +121,7 @@ select on the fly, on the command line.
 | free-tier | boolean | Instance Types that support IPv6 | unset |
 | cpu-arch | string | architecture of the CPU | unset, can be one of "x86_64/amd64", "x86_64_mac", "i386", "arm64" |
 | cpu-vendor | string | manufacturer of CPU | unset can be one of "amd", "intel", "aws" |
-| gpu-vendor | string | Vendor of the GPU | unset can be one of nvidia |
+| gpu-vendor | string | Vendor of the GPU | unset can be one of "AMD", "Habana", "NVIDIA" |
 | disk-type | string | type of disk, hard disk or solid state | unset  can be one of "hdd", "ssd" |
 | exclude-list | array | instance types which should be excluded w/ regex syntax (Example: `m[1-2]\.*)` | unset |
 | include-list | array | instance types which should be included w/ regex syntax (Example: `m[1-2]\.*)` | unset |


### PR DESCRIPTION
Hello! I noticed that `--gpu-vendor nvidia` was not working, so I updated the possible GPU vendors listed in `cloud-select/cloudselect/main/schemas.py` to match those I was seeing in `.cloud-select/cache/aws/instances.json`.

I can now filter for NVIDIA, AMD, or Habana GPUs:

```
$ cloud-select instance --cloud aws --gpus-min 2 --gpu-vendor NVIDIA
Update function for aws returned no results, will use previous data.
Update function for aws returned no results, will use previous data.
                                  Cloud Instances Selected
┏━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┓
┃ Cloud ┃ Name          ┃ Memory  ┃ Price   ┃ Cpus ┃ Gpus ┃ Region    ┃ Description        ┃
┡━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━╇━━━━━━╇━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━┩
│ aws   │ g5g.16xlarge  │ 131072  │ 2.744   │ 64   │ 2    │ us-east-1 │ 64 vCPUs, 128.0... │
│ aws   │ p4d.24xlarge  │ 1179648 │ 32.7726 │ 96   │ 8    │ us-east-1 │ 96 vCPUs, 1.1 T... │
│ aws   │ p5.48xlarge   │ 2097152 │ 98.32   │ 192  │ 8    │ us-east-1 │ 192 vCPUs, 2.0 ... │
│ aws   │ g4dn.12xlarge │ 196608  │ 3.912   │ 48   │ 4    │ us-east-1 │ 48 vCPUs, 192.0... │
│ aws   │ p2.8xlarge    │ 499712  │ 7.2     │ 32   │ 8    │ us-east-1 │ 32 vCPUs, 488.0... │
│ aws   │ p3dn.24xlarge │ 786432  │ 31.212  │ 96   │ 8    │ us-east-1 │ 96 vCPUs, 768.0... │
│ aws   │ p3.16xlarge   │ 499712  │ 24.48   │ 64   │ 8    │ us-east-1 │ 64 vCPUs, 488.0... │
│ aws   │ g5.12xlarge   │ 196608  │ 5.672   │ 48   │ 4    │ us-east-1 │ 48 vCPUs, 192.0... │
│ aws   │ g4dn.metal    │ 393216  │         │ 96   │ 8    │ us-east-1 │ 96 vCPUs, 384.0... │
│ aws   │ g3.16xlarge   │ 499712  │ 4.56    │ 64   │ 4    │ us-east-1 │ 64 vCPUs, 488.0... │
│ aws   │ p2.16xlarge   │ 749568  │ 14.4    │ 64   │ 16   │ us-east-1 │ 64 vCPUs, 732.0... │
│ aws   │ p3.8xlarge    │ 249856  │ 12.24   │ 32   │ 4    │ us-east-1 │ 32 vCPUs, 244.0... │
│ aws   │ g5.48xlarge   │ 786432  │ 16.288  │ 192  │ 8    │ us-east-1 │ 192 vCPUs, 768.... │
│ aws   │ g5g.metal     │ 131072  │         │ 64   │ 2    │ us-east-1 │ 64 vCPUs, 128.0... │
│ aws   │ g3.8xlarge    │ 249856  │ 2.28    │ 32   │ 2    │ us-east-1 │ 32 vCPUs, 244.0... │
│ aws   │ g5.24xlarge   │ 393216  │ 8.144   │ 96   │ 4    │ us-east-1 │ 96 vCPUs, 384.0... │
└───────┴───────────────┴─────────┴─────────┴──────┴──────┴───────────┴────────────────────┘
*Price in USD/hour
$ cloud-select instance --cloud aws --gpus-min 2 --gpu-vendor AMD
Update function for aws returned no results, will use previous data.
Update function for aws returned no results, will use previous data.
                                Cloud Instances Selected
┏━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┓
┃ Cloud ┃ Name          ┃ Memory ┃ Price ┃ Cpus ┃ Gpus ┃ Region    ┃ Description        ┃
┡━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━╇━━━━━━╇━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━┩
│ aws   │ g4ad.16xlarge │ 262144 │ 3.468 │ 64   │ 4    │ us-east-1 │ 64 vCPUs, 256.0... │
│ aws   │ g4ad.8xlarge  │ 131072 │ 1.734 │ 32   │ 2    │ us-east-1 │ 32 vCPUs, 128.0... │
└───────┴───────────────┴────────┴───────┴──────┴──────┴───────────┴────────────────────┘
*Price in USD/hour
$ cloud-select instance --cloud aws --gpus-min 2 --gpu-vendor Habana
Update function for aws returned no results, will use previous data.
Update function for aws returned no results, will use previous data.
                                 Cloud Instances Selected
┏━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┓
┃ Cloud ┃ Name         ┃ Memory ┃ Price    ┃ Cpus ┃ Gpus ┃ Region    ┃ Description        ┃
┡━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━╇━━━━━━╇━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━┩
│ aws   │ dl1.24xlarge │ 786432 │ 13.10904 │ 96   │ 8    │ us-east-1 │ 96 vCPUs, 768.0... │
└───────┴──────────────┴────────┴──────────┴──────┴──────┴───────────┴────────────────────┘
*Price in USD/hour
```

Hopefully this helps!