### PR TITLE
Add/google prices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/converged-computing/cloud-select/tree/main) (0.0.x)
+ - support for parsing Google prices and preemptible (spot) instances (0.0.25)
  - add support for since to aws spot prices (0.0.24)
  - support for aws spot prices (function to request) (0.0.23)
  - aws prices no longer works to receive an empty NextToken (0.0.22)

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022-2023 LLNS, LLC and other HPCIC DevTools Developers.
+Copyright (c) 2022-2024 LLNS, LLC and other HPCIC DevTools Developers.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/cloudselect/client/__init__.py
+++ b/cloudselect/client/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2022-2024 Lawrence Livermore National Security, LLC and other
 # HPCIC DevTools Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (MIT)

--- a/cloudselect/client/cache.py
+++ b/cloudselect/client/cache.py
@@ -1,4 +1,4 @@
-# Copyright 2022-2023 Lawrence Livermore National Security, LLC and other
+# Copyright 2022-2024 Lawrence Livermore National Security, LLC and other
 # HPCIC DevTools Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (MIT)

--- a/cloudselect/client/config.py
+++ b/cloudselect/client/config.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2022-2024 Lawrence Livermore National Security, LLC and other
 # HPCIC DevTools Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (MIT)

--- a/cloudselect/client/dbshell.py
+++ b/cloudselect/client/dbshell.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2022-2024 Lawrence Livermore National Security, LLC and other
 # HPCIC DevTools Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (MIT)

--- a/cloudselect/client/instance.py
+++ b/cloudselect/client/instance.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2022-2024 Lawrence Livermore National Security, LLC and other
 # HPCIC DevTools Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (MIT)

--- a/cloudselect/client/shell.py
+++ b/cloudselect/client/shell.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2022-2024 Lawrence Livermore National Security, LLC and other
 # HPCIC DevTools Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (MIT)

--- a/cloudselect/cloud/aws/client.py
+++ b/cloudselect/cloud/aws/client.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2022-2024 Lawrence Livermore National Security, LLC and other
 # HPCIC DevTools Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (MIT)

--- a/cloudselect/cloud/aws/client.py
+++ b/cloudselect/cloud/aws/client.py
@@ -6,6 +6,7 @@
 import json
 import random
 import re
+import statistics
 import time
 from datetime import datetime
 
@@ -93,6 +94,36 @@ class AmazonCloud(CloudProvider):
                 prices.append(json.loads(pricestr))
             print(f"{len(prices)} total aws prices matching {regex}...", end="\r")
         print()
+
+        # Try to add current spot
+        try:
+            updated = []
+            instances = self.instances()
+            spot_prices = self.spot_prices(instances)
+            for p in prices:
+                instance_type = p["product"]["attributes"].get("instanceType")
+                if not instance_type or instance_type not in spot_prices:
+                    continue
+                region = p["product"]["attributes"]["regionCode"]
+
+                # Save the availability zones, and the mean across
+                sps = {
+                    v["AvailabilityZone"]: float(v["SpotPrice"])
+                    for k, v in spot_prices[instance_type].items()
+                    if k.startswith(region)
+                }
+                if not sps:
+                    continue
+
+                p["terms"]["SpotPrices"] = sps
+                p["terms"]["SpotPrice"] = statistics.mean(list(sps.values()))
+                updated.append(p)
+            prices = updated
+
+        except Exception as e:
+            print(f"Issue with parsing spot prices: {e}")
+            pass
+
         return self.load_prices(prices)
 
     def spot_prices(self, instances, since=None, latest=True):

--- a/cloudselect/cloud/aws/instance.py
+++ b/cloudselect/cloud/aws/instance.py
@@ -1,4 +1,4 @@
-# Copyright 2022-2023 Lawrence Livermore National Security, LLC and other
+# Copyright 2022-2024 Lawrence Livermore National Security, LLC and other
 # HPCIC DevTools Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (MIT)

--- a/cloudselect/cloud/aws/instance.py
+++ b/cloudselect/cloud/aws/instance.py
@@ -34,6 +34,12 @@ class AmazonInstance(Instance):
         """
         return self.data.get("Price")
 
+    def attr_spot_price(self):
+        """
+        Spot price of an instance, USD per hour.
+        """
+        return self.data.get("SpotPrice")
+
     def attr_region(self):
         """
         Return the single region
@@ -89,12 +95,6 @@ class AmazonInstance(Instance):
         Return if the instance suports storage
         """
         return self.data.get("InstanceStorageSupported")
-
-    def attr_price_per_hour(self):
-        """
-        Return price per hour, if known.
-        """
-        return self.data.get("Price")
 
     def attr_gpu_model(self):
         """
@@ -213,7 +213,8 @@ class AmazonInstanceGroup(InstanceGroup):
             # Provide finally as single region and price
             for region in regions:
                 item["Region"] = region
-                item["Price"] = item.get("Prices", {}).get(region)
+                item["Price"] = item.get("Prices", {}).get(region, {}).get("OnDemand")
+                item["SpotPrice"] = item.get("Prices", {}).get(region, {}).get("Spot")
                 yield self.Instance(item)
 
     def add_instance_prices(self, prices):
@@ -234,7 +235,7 @@ class AmazonInstanceGroup(InstanceGroup):
                 for region in instance["Regions"]:
                     if region in lookup[instance["InstanceType"]]:
                         region_prices[region] = lookup[instance["InstanceType"]][region]
-                    instance["Prices"] = region_prices
+                instance["Prices"] = region_prices
 
 
 def build_instance_price_lookup(prices):
@@ -270,6 +271,9 @@ def build_instance_price_lookup(prices):
         location = price["product"]["attributes"]["regionCode"]
         instance_type = price["product"]["attributes"]["instanceType"]
 
+        # If we have a spot price
+        spot_price = price["terms"].get("SpotPrice")
+
         assert len(price["terms"]["OnDemand"]) == 1
         priceid = list(price["terms"]["OnDemand"].keys())[0]
         for _, rate in price["terms"]["OnDemand"][priceid]["priceDimensions"].items():
@@ -278,8 +282,12 @@ def build_instance_price_lookup(prices):
                     lookup[instance_type] = {}
                 if location in lookup[instance_type]:
                     logger.warning(
-                        f"Found two rates for {instance_type} in {location} - we will choose one but this likely should not happen."
+                        f"Found more than one entry for {instance_type} in {location} - we will choose one but this likely should not happen."
                     )
+
                 # These are provided as strings, since the original data is completely string
-                lookup[instance_type][location] = float(rate["pricePerUnit"]["USD"])
+                lookup[instance_type][location] = {
+                    "OnDemand": float(rate["pricePerUnit"]["USD"]),
+                    "Spot": spot_price,
+                }
     return lookup

--- a/cloudselect/cloud/aws/prices.py
+++ b/cloudselect/cloud/aws/prices.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2022-2024 Lawrence Livermore National Security, LLC and other
 # HPCIC DevTools Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (MIT)

--- a/cloudselect/cloud/base.py
+++ b/cloudselect/cloud/base.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2022-2024 Lawrence Livermore National Security, LLC and other
 # HPCIC DevTools Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (MIT)

--- a/cloudselect/cloud/base.py
+++ b/cloudselect/cloud/base.py
@@ -175,6 +175,7 @@ class Instance(CloudData):
             "name": self.name,
             "memory": self.attr_memory(),
             "price": self.attr_price(),
+            "spot_price": self.attr_spot_price(),
             "cpus": self.attr_cpus(),
             "gpus": self.attr_gpus(),
             "region": self.attr_region(),

--- a/cloudselect/cloud/google/client.py
+++ b/cloudselect/cloud/google/client.py
@@ -28,6 +28,8 @@ class GoogleCloud(CloudProvider):
         self.regions = kwargs.get("regions") or ["us-east1", "us-west1", "us-central1"]
         self.project = None
         self.compute_cli = None
+        # This is the pricing api - billing is for our usage
+        # https://cloud.google.com/billing/docs/how-to/get-pricing-information-api
         self.billing_cli = None
         try:
             self._set_services(kwargs.get("cache_only"))
@@ -35,6 +37,15 @@ class GoogleCloud(CloudProvider):
             logger.warning(f"Cannot create Google Cloud clients {e}")
             self.has_auth = False
         super(GoogleCloud, self).__init__()
+
+    def spot_prices(self, instances, since=None, latest=True):
+        """
+        Get spot prices for a set of instances and availability zones
+
+        This is currently not implemented because we add spot prices to
+        the normal pricing data, but could be added if needed.
+        """
+        pass
 
     def prices(self):
         """
@@ -116,7 +127,9 @@ class GoogleCloud(CloudProvider):
         # Get accelerator types (for GPU) to add to them?
         # TODO - I don't see where we can get memory for GPUs :(
         # https://cloud.google.com/compute/docs/reference/rest/v1/acceleratorTypes
-        # accels = self._retry_request(self.compute_cli.acceleratorTypes().aggregatedList(project=self.project))
+        # accels = self._retry_request(
+        #    self.compute_cli.acceleratorTypes().aggregatedList(project=self.project)
+        # )
 
         # Return a wrapped set of instances
         return self.load_instances(machine_types)

--- a/cloudselect/cloud/google/client.py
+++ b/cloudselect/cloud/google/client.py
@@ -1,4 +1,4 @@
-# Copyright 2022-2023 Lawrence Livermore National Security, LLC and other
+# Copyright 2022-2024 Lawrence Livermore National Security, LLC and other
 # HPCIC DevTools Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (MIT)

--- a/cloudselect/cloud/google/instance.py
+++ b/cloudselect/cloud/google/instance.py
@@ -1,4 +1,4 @@
-# Copyright 2022-2023 Lawrence Livermore National Security, LLC and other
+# Copyright 2022-2024 Lawrence Livermore National Security, LLC and other
 # HPCIC DevTools Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (MIT)

--- a/cloudselect/cloud/google/prices.py
+++ b/cloudselect/cloud/google/prices.py
@@ -1,4 +1,4 @@
-# Copyright 2022-2023 Lawrence Livermore National Security, LLC and other
+# Copyright 2022-2024 Lawrence Livermore National Security, LLC and other
 # HPCIC DevTools Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (MIT)

--- a/cloudselect/defaults.py
+++ b/cloudselect/defaults.py
@@ -23,7 +23,7 @@ cache_dir = os.path.join(userhome, "cache")
 cache_expire = 128  # one week is 128 hours
 
 # Fields and arguments for client
-sort_by_fields = ["name", "memory", "cpus", "gpus", "price"]
+sort_by_fields = ["name", "memory", "cpus", "gpus", "price", "spot_price"]
 table_descriptors = {"price": "*Price in USD/hour"}
 
 # variables in settings that allow environment variable expansion

--- a/cloudselect/defaults.py
+++ b/cloudselect/defaults.py
@@ -1,4 +1,4 @@
-# Copyright 2022-2023 Lawrence Livermore National Security, LLC and other
+# Copyright 2022-2024 Lawrence Livermore National Security, LLC and other
 # HPCIC DevTools Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (MIT)

--- a/cloudselect/main/cache.py
+++ b/cloudselect/main/cache.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2022-2024 Lawrence Livermore National Security, LLC and other
 # HPCIC DevTools Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (MIT)

--- a/cloudselect/main/client.py
+++ b/cloudselect/main/client.py
@@ -111,6 +111,11 @@ class Client:
         returns data we have available.
         """
         items = {}
+
+        # If directed not to use a cache, return early
+        if not self.use_cache:
+            return items
+
         for cloud in self.get_clouds():
             # Assume we don't find data
             data = None

--- a/cloudselect/main/client.py
+++ b/cloudselect/main/client.py
@@ -1,4 +1,4 @@
-# Copyright 2022-2023 Lawrence Livermore National Security, LLC and other
+# Copyright 2022-2024 Lawrence Livermore National Security, LLC and other
 # HPCIC DevTools Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (MIT)

--- a/cloudselect/main/colors.py
+++ b/cloudselect/main/colors.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2022-2024 Lawrence Livermore National Security, LLC and other
 # HPCIC DevTools Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (MIT)

--- a/cloudselect/main/oras.py
+++ b/cloudselect/main/oras.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2022-2024 Lawrence Livermore National Security, LLC and other
 # HPCIC DevTools Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (MIT)

--- a/cloudselect/main/schemas.py
+++ b/cloudselect/main/schemas.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2022-2024 Lawrence Livermore National Security, LLC and other
 # HPCIC DevTools Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (MIT)

--- a/cloudselect/main/schemas.py
+++ b/cloudselect/main/schemas.py
@@ -92,17 +92,29 @@ instance_properties = {
         "description": "Maximum number of vcpus available to the instance type. If min not set, is 0.",
     },
     # It seems unlikely to find an exact price, but might as well be consistent!
-    "price-per-hour": {
+    "price": {
         "type": "number",
         "description": "Price/hour in dollars (e.g., 0.09) (sets min and max to the same value)",
     },
-    "price-per-hour-min": {
+    "price-min": {
         "type": "number",
         "description": "Minimum price/hour in dollars. If max not set, is infinity.",
     },
-    "price-per-hour-max": {
+    "price-max": {
         "type": "number",
         "description": "Maximum price/hour in dollars. If min not set, is 0.",
+    },
+    "spot-price": {
+        "type": "number",
+        "description": "Price/hour for spot in dollars (e.g., 0.09) (sets min and max to the same value)",
+    },
+    "spot-price-min": {
+        "type": "number",
+        "description": "Minimum spot price/hour in dollars. If max not set, is infinity.",
+    },
+    "spot-price-max": {
+        "type": "number",
+        "description": "Maximum spot price/hour in dollars. If min not set, is 0.",
     },
     "free-tier": {"type": "boolean", "description": "Free tier only."},
     "ipv6": {"type": "boolean", "description": "Instance Types that support IPv6"},
@@ -137,24 +149,6 @@ instance_properties = {
         "description": "instance types which should be included w/ regex syntax (Example: m[1-2]\.*)",  # noqa
     },
 }
-
-# These are not added yet (and available for AWS) if we want to add them
-#      --network-encryption                             Instance Types that support automatic network encryption in-transit
-#      --network-interfaces int                         Number of network interfaces (ENIs) that can be attached to the instance (sets --network-interfaces-min and -max to the same value)
-#      --network-interfaces-max int                     Maximum Number of network interfaces (ENIs) that can be attached to the instance If --network-interfaces-min is not specified, the lower bound will be 0
-#      --network-interfaces-min int                     Minimum Number of network interfaces (ENIs) that can be attached to the instance If --network-interfaces-max is not specified, the upper bound will be infinity
-#      --network-performance int                        Bandwidth in Gib/s of network performance (Example: 100) (sets --network-performance-min and -max to the same value)
-#      --network-performance-max int                    Maximum Bandwidth in Gib/s of network performance (Example: 100) If --network-performance-min is not specified, the lower bound will be 0
-#      --network-performance-min int                    Minimum Bandwidth in Gib/s of network performance (Example: 100) If --network-performance-max is not specified, the upper bound will be infinity
-#      --nvme                                           EBS or local instance storage where NVME is supported or required
-#      --placement-group-strategy string                Placement group strategy: [cluster, partition, spread]
-#  -u, --usage-class string                             Usage class: [spot or on-demand]
-#      --virtualization-type string                     Virtualization Type supported: [hvm or pv]
-#  -o, --output string           Specify the output format (table, table-wide, one-line, interactive)
-#      --profile string          AWS CLI profile to use for credentials and config
-#  -r, --region string           AWS Region to use for API requests (NOTE: if not passed in, uses AWS SDK default precedence)
-#      --sort-by string          Specify the field to sort by. Quantity flags present in this CLI (memory, gpus, etc.) or a JSON path to the appropriate instance type field (Ex: ".MemoryInfo.SizeInMiB") is acceptable. (default ".InstanceType")
-#      --sort-direction string   Specify the direction to sort in (ascending, asc, descending, desc) (default "ascending")
 
 ## Settings.yml (loads as json)
 

--- a/cloudselect/main/selectors.py
+++ b/cloudselect/main/selectors.py
@@ -1,4 +1,4 @@
-# Copyright 2022-2023 Lawrence Livermore National Security, LLC and other
+# Copyright 2022-2024 Lawrence Livermore National Security, LLC and other
 # HPCIC DevTools Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (MIT)

--- a/cloudselect/main/settings.py
+++ b/cloudselect/main/settings.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2022-2024 Lawrence Livermore National Security, LLC and other
 # HPCIC DevTools Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (MIT)

--- a/cloudselect/main/solve/database.py
+++ b/cloudselect/main/solve/database.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2022-2024 Lawrence Livermore National Security, LLC and other
 # HPCIC DevTools Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (MIT)

--- a/cloudselect/main/solve/properties.py
+++ b/cloudselect/main/solve/properties.py
@@ -17,7 +17,8 @@ class Properties:
         "instance_storage",
         "memory",
         "gpu_memory",
-        "price_per_hour",
+        "spot_price",
+        "price",
     ]
 
     def __init__(self, properties, **kwargs):

--- a/cloudselect/main/solve/properties.py
+++ b/cloudselect/main/solve/properties.py
@@ -1,4 +1,4 @@
-# Copyright 2022-2023 Lawrence Livermore National Security, LLC and other
+# Copyright 2022-2024 Lawrence Livermore National Security, LLC and other
 # HPCIC DevTools Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (MIT)

--- a/cloudselect/main/solve/solver.py
+++ b/cloudselect/main/solve/solver.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2022-2024 Lawrence Livermore National Security, LLC and other
 # HPCIC DevTools Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (MIT)

--- a/cloudselect/main/table.py
+++ b/cloudselect/main/table.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2022-2024 Lawrence Livermore National Security, LLC and other
 # HPCIC DevTools Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (MIT)

--- a/cloudselect/tests/helpers.py
+++ b/cloudselect/tests/helpers.py
@@ -1,10 +1,9 @@
 #!/usr/bin/python
 
-# Copyright (C) 2022-2023 Vanessa Sochat.
-
-# This Source Code Form is subject to the terms of the
-# Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-# with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# Copyright 2022-2024 Lawrence Livermore National Security, LLC and other
+# HPCIC DevTools Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
 
 import os
 import shlex

--- a/cloudselect/tests/test_instance.py
+++ b/cloudselect/tests/test_instance.py
@@ -157,7 +157,6 @@ def test_instance_filters(tmp_path, cloud, prices_file, instances_file, region):
         "gpu-model",
         "hypervisor",
         "instance-storage",
-        "price-per-hour",
         "cpu-arch",
         "cpu-vendor",
         "gpu-vendor",
@@ -236,19 +235,19 @@ def test_aws_instance_filters(tmp_path, cloud):
             assert attr in result
 
     # Note that --max-results is handled by the client directly
-    args = parse_args("instance --price-per-hour-min 1.0")
+    args = parse_args("instance --price-min 1.0")
     results = client.instance_select(**args.__dict__)
     assert len(results) == 9
     for result in results:
         assert result["price"] >= 1.0
 
-    args = parse_args("instance --price-per-hour-max 2.0")
+    args = parse_args("instance --price-max 2.0")
     results = client.instance_select(**args.__dict__)
     assert len(results) == 13
     for result in results:
         assert result["price"] <= 2.0
 
-    args = parse_args("instance --price-per-hour-min 1.0 --price-per-hour-max 2.0")
+    args = parse_args("instance --price-min 1.0 --price-max 2.0")
     results = client.instance_select(**args.__dict__)
     assert len(results) == 3
     for result in results:
@@ -326,7 +325,6 @@ def test_interactive_database_aws(tmp_path):
         "memory",
         "memory_bytes",
         "price",
-        "price_per_hour",
         "region",
         "gpu",
         "gpu_memory",

--- a/cloudselect/tests/test_instance.py
+++ b/cloudselect/tests/test_instance.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-# Copyright 2022-2023 Lawrence Livermore National Security, LLC and other
+# Copyright 2022-2024 Lawrence Livermore National Security, LLC and other
 # HPCIC DevTools Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (MIT)

--- a/cloudselect/tests/test_selector.py
+++ b/cloudselect/tests/test_selector.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-# Copyright 2022-2023 Lawrence Livermore National Security, LLC and other
+# Copyright 2022-2024 Lawrence Livermore National Security, LLC and other
 # HPCIC DevTools Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (MIT)

--- a/cloudselect/tests/test_settings.py
+++ b/cloudselect/tests/test_settings.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-# Copyright 2022-2023 Lawrence Livermore National Security, LLC and other
+# Copyright 2022-2024 Lawrence Livermore National Security, LLC and other
 # HPCIC DevTools Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (MIT)

--- a/cloudselect/tests/test_utils.py
+++ b/cloudselect/tests/test_utils.py
@@ -1,10 +1,9 @@
 #!/usr/bin/python
 
-# Copyright (C) 2021-2023 Vanessa Sochat.
-
-# This Source Code Form is subject to the terms of the
-# Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-# with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# Copyright 2022-2024 Lawrence Livermore National Security, LLC and other
+# HPCIC DevTools Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
 
 import json
 import os

--- a/cloudselect/utils/fileio.py
+++ b/cloudselect/utils/fileio.py
@@ -1,4 +1,4 @@
-# Copyright 2022-2023 Lawrence Livermore National Security, LLC and other
+# Copyright 2022-2024 Lawrence Livermore National Security, LLC and other
 # HPCIC DevTools Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (MIT)

--- a/cloudselect/utils/misc.py
+++ b/cloudselect/utils/misc.py
@@ -1,4 +1,4 @@
-# Copyright 2022-2023 Lawrence Livermore National Security, LLC and other
+# Copyright 2022-2024 Lawrence Livermore National Security, LLC and other
 # HPCIC DevTools Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (MIT)

--- a/cloudselect/version.py
+++ b/cloudselect/version.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (MIT)
 
-__version__ = "0.0.24"
+__version__ = "0.0.25"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "cloud-select-tool"

--- a/cloudselect/version.py
+++ b/cloudselect/version.py
@@ -1,4 +1,4 @@
-# Copyright 2022-2023 Lawrence Livermore National Security, LLC and other
+# Copyright 2022-2024 Lawrence Livermore National Security, LLC and other
 # HPCIC DevTools Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (MIT)

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -115,9 +115,12 @@ select on the fly, on the command line.
 | cpus |number |Number of vcpus available to the instance type. Sets min and -max to the same value. | unset |
 | cpus-min | number | Minimum number of vcpus available to the instance type. If max not set, is infinity. | unset |
 | cpus-max | number | Maximum number of vcpus available to the instance type. If min not set, is 0. | unset |
-| price-per-hour | number | Price/hour in dollars (e.g., 0.09) (sets min and max to the same value) | unset |
-| price-per-hour-min | number | Minimum price/hour in dollars. If max not set, is infinity. | unset |
-| price-per-hour-max | number |Maximum price/hour in dollars. If min not set, is 0." | unset |
+| price | number | Price/hour in dollars (e.g., 0.09) (sets min and max to the same value) | unset |
+| price-min | number | Minimum price/hour in dollars. If max not set, is infinity. | unset |
+| price-max | number | Maximum price/hour in dollars. If min not set, is 0." | unset |
+| spot-price | number | Spot Price/hour in dollars (e.g., 0.09) (sets min and max to the same value) | unset |
+| spot-price-min | number | Minimum spot price/hour in dollars. If max not set, is infinity. | unset |
+| spot-price-max | number | Maximum spot price/hour in dollars. If min not set, is 0." | unset |
 | free-tier | boolean | Instance Types that support IPv6 | unset |
 | cpu-arch | string | architecture of the CPU | unset, can be one of "x86_64/amd64", "x86_64_mac", "i386", "arm64" |
 | cpu-vendor | string | manufacturer of CPU | unset can be one of "amd", "intel", "aws" |

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -157,14 +157,14 @@ $ cloud-select --max-results 100 instance
 Or try filtering by price:
 
 ```bash
-$ cloud-select instance --price-per-hour-min 1.0
+$ cloud-select instance --price-min 1.0
 ```
 
 And also sorting, of course, either default or ascending:
 
 ```bash
-$ cloud-select instance --price-per-hour-min 1.0 --sort-by price
-$ cloud-select instance --price-per-hour-min 1.0 --sort-by price --asc
+$ cloud-select instance --price-min 1.0 --sort-by price
+$ cloud-select instance --price-min 1.0 --sort-by price --asc
 ```
 
 ![img/cloud-select-prices.png](img/cloud-select-prices.png)
@@ -273,7 +273,6 @@ CREATE TABLE IF NOT EXISTS instances (
     value_bool number NULLABLE,
     value_number number NULLABLE
 );
-Google Cloud instance prices derived from the web are limited to Iowa (us-centra-1)
 ```
 
 This will prepare the same database for you as used in the command line
@@ -317,7 +316,7 @@ What attributes are available for query (aside from exact fields shown above)? L
  ('memory',),
  ('memory_bytes',),
  ('price',),
- ('price_per_hour',),
+ ('spot_price',),
  ('region',),
  ('zone',)]
 ```
@@ -348,7 +347,6 @@ out for the remainder of these examples. Here is querying for an instance name:
 ```
 ```console
  (23252, ..., 'google', 'n2d-highcpu-224', 'price', None, None, 6.986112),
- (23253, ..., 'google', 'n2d-highcpu-224', 'price_per_hour', None, None, 6.986112),
  (23254, ..., 'google', 'n2d-highcpu-224', 'region', 'us-west1-a', None, None),
  (23255, ..., 'google', 'n2d-highcpu-224', 'zone', 'us-west1-a', None, None)]
 ```


### PR DESCRIPTION
This is a WIP that adds the ability to get actual on demand (and preemptible or spot) prices from the Google API. It's a really weird  API to figure out - you have to convert nanos into a unit, and then multiply for each of cpus / memory to get a price. I need to do some more spot checks, and likely factor in other small variables that influence price (that may not be reflected here).