### PR TITLE
oras: update auth interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/converged-computing/cloud-select/tree/main) (0.0.x)
+ - oras min version 0.2.25 to support updated auth interface (0.1.0)
  - support for parsing Google prices and preemptible (spot) instances (0.0.25)
  - add support for since to aws spot prices (0.0.24)
  - support for aws spot prices (function to request) (0.0.23)

--- a/cloudselect/main/oras.py
+++ b/cloudselect/main/oras.py
@@ -24,7 +24,7 @@ def get_oras_client(require_auth=False):
     reg = Registry()
     if user and password:
         logger.debug("Found username and password for basic auth")
-        reg.set_basic_auth(user, password)
+        reg.auth.set_basic_auth(user, password)
     else:
         logfunc = logger.exit if require_auth else logger.debug
         logfunc("ORAS_USER or ORAS_PASS is missing, push may have issues.")

--- a/cloudselect/version.py
+++ b/cloudselect/version.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (MIT)
 
-__version__ = "0.0.25"
+__version__ = "0.1.0"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "cloud-select-tool"
@@ -21,7 +21,7 @@ INSTALL_REQUIRES = (
     ("ruamel.yaml", {"min_version": None}),
     ("jsonschema", {"min_version": None}),
     ("rich", {"min_version": None}),
-    ("oras", {"min_version": None}),
+    ("oras", {"min_version": "0.2.25 "}),
     ("requests", {"min_version": None}),
     ("pick", {"min_version": None}),
 )


### PR DESCRIPTION
And pin to 0.2.25 that has a mostly working interface. The difference is that we interact with the registry client .auth instead of directly.